### PR TITLE
Fix/vim tabline

### DIFF
--- a/nvim/colors/koe.vim
+++ b/nvim/colors/koe.vim
@@ -91,9 +91,9 @@ hi myStatic ctermfg=15
 
 hi Error ctermfg=8 ctermbg=1
 
-hi TabLine ctermfg=0 ctermbg=7
+hi TabLine ctermfg=8 ctermbg=0
 hi TabLineSel ctermfg=7 ctermbg=0 cterm=NONE
-hi TabLineFill ctermfg=7 ctermbg=0
+hi TabLineFill ctermfg=0 ctermbg=8
 hi VertSplit ctermbg=0 ctermfg=0
 
 hi Search cterm=bold ctermfg=0 ctermbg=1

--- a/nvim/colors/koe.vim
+++ b/nvim/colors/koe.vim
@@ -91,9 +91,9 @@ hi myStatic ctermfg=15
 
 hi Error ctermfg=8 ctermbg=1
 
-hi TabLine ctermbg=0 ctermfg=0
-hi TabLineSel ctermfg=0 ctermbg=0
-hi TabLineFill ctermfg=0 ctermbg=0
+hi TabLine ctermfg=0 ctermbg=7
+hi TabLineSel ctermfg=7 ctermbg=0 cterm=NONE
+hi TabLineFill ctermfg=7 ctermbg=0
 hi VertSplit ctermbg=0 ctermfg=0
 
 hi Search cterm=bold ctermfg=0 ctermbg=1

--- a/nvim/colors/koe.vim
+++ b/nvim/colors/koe.vim
@@ -102,7 +102,6 @@ hi Visual ctermfg=8 ctermbg=1 cterm=NONE
 hi PreProc ctermfg=10
 hi MatchParen cterm=bold ctermbg=NONE ctermfg=10
 
-hi StatusLine ctermfg=7 ctermbg=0
+hi StatusLine ctermfg=7 ctermbg=0 cterm=NONE
 hi StatusLineNC ctermfg=7 ctermbg=0
 hi CursorLine ctermfg=7 ctermbg=0 cterm=NONE
-hi StatusLine ctermfg=7 ctermbg=0 cterm=NONE


### PR DESCRIPTION
Right now, the tab line isn't visible. This pull request addresses this by making it mimic the colors of the status line.

The tab line is using the colors of an inactive status line and the currently selected tab is using the colors of an active status line. I'm not sure if that sticks out too much? Perhaps an alternative would be to always use the active status line colors and only distinguish the tabs from the active one using **bold**.